### PR TITLE
feat(stats-cards): Override native error for consistency

### DIFF
--- a/custom-api/stats-cards/README.md
+++ b/custom-api/stats-cards/README.md
@@ -36,4 +36,9 @@ pages:
                   $include: paperless-ngx.yml
 ```
 
+## Error Handling
+If you're using properties like `url` or `subrequests`, you'd usually need to add `skip-json-validation: true` in each of them to avoid native error handling. But with the `custom-api` helper function `newRequest`, there's no built-in error handling to begin with—so that property isn't needed.
+
+---
+
 inspired by [Homepage](https://gethomepage.dev/)

--- a/custom-api/stats-cards/_stat-template.gohtml
+++ b/custom-api/stats-cards/_stat-template.gohtml
@@ -35,9 +35,20 @@
 {{ end }}
 
 {{ define "stat-value" }}
-  <div class="color-highlight size-h4">{{ . }}</div>
+  <div class="color-highlight size-h4 text-truncate">{{ . }}</div>
+{{ end }}
+
+{{ define "stat-value-negative" }}
+  <div class="color-negative size-h4 text-truncate">{{ . }}</div>
 {{ end }}
 
 {{ define "stat-label" }}
-  <div class="size-h5 uppercase">{{ . }}</div>
+  <div class="size-h5 uppercase text-truncate">{{ . }}</div>
+{{ end }}
+
+{{ define "stat-fail" }}
+  <div>
+    {{ template "stat-value-negative" . }}
+    {{ template "stat-label" "ERROR" }}
+  </div>
 {{ end }}

--- a/custom-api/stats-cards/frigate.yml
+++ b/custom-api/stats-cards/frigate.yml
@@ -5,6 +5,7 @@
   hide-header: true
   allow-insecure: true
   skip-tls-verify: true
+  skip-json-validation: true
   cache: 1m
   template: | #html
     $include: _stat-template.gohtml
@@ -14,18 +15,22 @@
           {{ template "logo" "${DASHBOARD_ICONS}/svg/frigate-light.svg" }}
           {{ template "title-container" }}
             {{ template "title" "Frigate" }}
-            <!-- {{ template "subtitle" "NVR" }} -->
+            <!-- {{ template "subtitle" "Security Camera System" }} -->
           </div>
         </div>
       </a>
       {{ template "stat-container" }}
-        <div>
-          {{ template "stat-value" .JSON.Int "last24Hours.total_alert" | formatNumber }}
-          {{ template "stat-label" "ALERT" }}
-        </div>
-        <div>
-          {{ template "stat-value" .JSON.Int "last24Hours.total_detection" | formatNumber }}
-          {{ template "stat-label" "DETECTION" }}
-        </div>
+        {{ if eq .Response.StatusCode 200 }}
+          <div>
+            {{ template "stat-value" .JSON.Int "last24Hours.total_alert" | formatNumber }}
+            {{ template "stat-label" "ALERT" }}
+          </div>
+          <div>
+            {{ template "stat-value" .JSON.Int "last24Hours.total_detection" | formatNumber }}
+            {{ template "stat-label" "DETECTION" }}
+          </div>
+        {{ else }}
+          {{ template "stat-fail" .Response.Status }}
+        {{ end }}
       </div>
     </div>

--- a/custom-api/stats-cards/immich.yml
+++ b/custom-api/stats-cards/immich.yml
@@ -1,11 +1,12 @@
 - type: custom-api
-  cache: 1m
   url: https://${IMMICH_URL}/api/server/statistics
   css-class: glimpsable-custom
   hide-header: true
   headers:
     x-api-key: ${IMMICH_KEY}
     Accept: application/json
+  skip-json-validation: true
+  cache: 1m
   template: | #html
     $include: _stat-template.gohtml
     {{ template "main-container" }}
@@ -19,17 +20,21 @@
         </div>
       </a>
       {{ template "stat-container" }}
-        <div>
-          {{ template "stat-value" .JSON.Int "photos" | formatNumber }}
-          {{ template "stat-label" "PHOTOS" }}
-        </div>
-        <div>
-          {{ template "stat-value" .JSON.Int "videos" | formatNumber }}
-          {{ template "stat-label" "VIDEOS" }}
-        </div>
-        <div>
-          {{ template "stat-value" (printf "%s<span style='color: var(--color-text-base);'>GB</span>" (div (.JSON.Int "usage" | toFloat) 1073741824 | toInt | formatNumber) | safeHTML) }}
-          {{ template "stat-label" "USAGE" }}
-        </div>
+        {{ if eq .Response.StatusCode 200 }}
+          <div>
+            {{ template "stat-value" .JSON.Int "photos" | formatNumber }}
+            {{ template "stat-label" "PHOTOS" }}
+          </div>
+          <div>
+            {{ template "stat-value" .JSON.Int "videos" | formatNumber }}
+            {{ template "stat-label" "VIDEOS" }}
+          </div>
+          <div>
+            {{ template "stat-value" (printf "%s<span style='color: var(--color-text-base);'>GB</span>" (div (.JSON.Int "usage" | toFloat) 1073741824 | toInt | formatNumber) | safeHTML) }}
+            {{ template "stat-label" "USAGE" }}
+          </div>
+        {{ else }}
+          {{ template "stat-fail" .Response.Status }}
+        {{ end }}
       </div>
     </div>

--- a/custom-api/stats-cards/jellyfin.yml
+++ b/custom-api/stats-cards/jellyfin.yml
@@ -1,11 +1,12 @@
 - type: custom-api
-  cache: 1m
   url: https://${JELLYFIN_URL}/items/counts
   css-class: glimpsable-custom
   hide-header: true
   headers:
     Authorization: MediaBrowser Token=${JELLYFIN_KEY}
     Accept: application/json
+  skip-json-validation: true
+  cache: 1m
   template: | #html
     $include: _stat-template.gohtml
     {{ template "main-container" }}
@@ -19,21 +20,25 @@
         </div>
       </a>
       {{ template "stat-container" }}
-        <div>
-          {{ template "stat-value" .JSON.Int "MovieCount" | formatNumber }}
-          {{ template "stat-label" "MOVIES" }}
-        </div>
-        <div>
-          {{ template "stat-value" .JSON.Int "SeriesCount" | formatNumber }}
-          {{ template "stat-label" "SERIES" }}
-        </div>
-        <div>
-          {{ template "stat-value" .JSON.Int "EpisodeCount" | formatNumber }}
-          {{ template "stat-label" "EPISODES" }}
-        </div>
-        <div>
-          {{ template "stat-value" .JSON.Int "SongCount" | formatNumber }}
-          {{ template "stat-label" "SONGS" }}
-        </div>
+        {{ if eq .Response.StatusCode 200 }}
+          <div>
+            {{ template "stat-value" .JSON.Int "MovieCount" | formatNumber }}
+            {{ template "stat-label" "MOVIES" }}
+          </div>
+          <div>
+            {{ template "stat-value" .JSON.Int "SeriesCount" | formatNumber }}
+            {{ template "stat-label" "SERIES" }}
+          </div>
+          <div>
+            {{ template "stat-value" .JSON.Int "EpisodeCount" | formatNumber }}
+            {{ template "stat-label" "EPISODES" }}
+          </div>
+          <div>
+            {{ template "stat-value" .JSON.Int "SongCount" | formatNumber }}
+            {{ template "stat-label" "SONGS" }}
+          </div>
+        {{ else }}
+          {{ template "stat-fail" .Response.Status }}
+        {{ end }}
       </div>
     </div>

--- a/custom-api/stats-cards/paperless-ngx.yml
+++ b/custom-api/stats-cards/paperless-ngx.yml
@@ -1,11 +1,12 @@
 - type: custom-api
-  cache: 1m
   url: https://${PAPERLESS_URL}/api/statistics/
   css-class: glimpsable-custom
   hide-header: true
   headers:
     Authorization: Token ${PAPERLESS_KEY}
     Accept: application/json
+  skip-json-validation: true
+  cache: 1m
   template: | #html
     $include: _stat-template.gohtml
     {{ template "main-container" }}
@@ -19,17 +20,21 @@
         </div>
       </a>
       {{ template "stat-container" }}
-        <div>
-          {{ template "stat-value" .JSON.Int "documents_total" | formatNumber }}
-          {{ template "stat-label" "Documents" }}
-        </div>
-        <div>
-          {{ template "stat-value" .JSON.Int "documents_inbox" | formatNumber }}
-          {{ template "stat-label" "Inbox" }}
-        </div>
-        <div>
-          {{ template "stat-value" .JSON.Int "character_count" | formatNumber }}
-          {{ template "stat-label" "Characters" }}
-        </div>
+        {{ if eq .Response.StatusCode 200 }}
+          <div>
+            {{ template "stat-value" .JSON.Int "documents_total" | formatNumber }}
+            {{ template "stat-label" "Documents" }}
+          </div>
+          <div>
+            {{ template "stat-value" .JSON.Int "documents_inbox" | formatNumber }}
+            {{ template "stat-label" "Inbox" }}
+          </div>
+          <div>
+            {{ template "stat-value" .JSON.Int "character_count" | formatNumber }}
+            {{ template "stat-label" "Characters" }}
+          </div>
+        {{ else }}
+          {{ template "stat-fail" .Response.Status }}
+        {{ end }}
       </div>
     </div>

--- a/custom-api/stats-cards/proxmox-ve.yml
+++ b/custom-api/stats-cards/proxmox-ve.yml
@@ -1,12 +1,13 @@
 - type: custom-api
   title: Proxmox
-  cache: 1s
   url: https://${PROXMOXVE_URL}/api2/json/cluster/resources
   css-class: glimpsable-custom
   hide-header: true
   headers:
     Accept: application/json
     Authorization: PVEAPIToken=${PROXMOXVE_KEY}
+  skip-json-validation: true
+  cache: 1m
   template: | #html
     $include: _stat-template.gohtml
     {{ template "main-container" }}
@@ -15,34 +16,38 @@
           {{ template "logo" "${DASHBOARD_ICONS}/svg/proxmox.svg" }}
           {{ template "title-container" }}
             {{ template "title" "Proxmox VE" }}
-            <!-- {{ template "subtitle" "Hypervisor" }} -->
+            <!-- {{ template "subtitle" "Virtualization Platform" }} -->
           </div>
         </div>
       </a>
       {{ template "stat-container" }}
-        {{ $nodes_online := len (.JSON.Array "data.#(type==\"node\")#|#(status==\"online\")#") | formatNumber }}
-        {{ $nodes_total := len (.JSON.Array "data.#(type==\"node\")#") }}
-        <div>
-          {{ template "stat-value" (concat $nodes_online "/" ($nodes_total | formatNumber)) }}
-          {{ template "stat-label" "Node" }}
-        </div>
-        <div>
-          {{ $lxc_running := len (.JSON.Array "data.#(type==\"lxc\")#|#(status==\"running\")#|#(template==0)#") | formatNumber }}
-          {{ $lxc_total := len (.JSON.Array "data.#(type==\"lxc\")#|#(template==0)#") | formatNumber }}
-          {{ template "stat-value" (concat $lxc_running "/" $lxc_total) }}
-          {{ template "stat-label" "LXC" }}
-        </div>
-        <div>
-          {{ $qemu_running := len (.JSON.Array "data.#(type==\"qemu\")#|#(status==\"running\")#|#(template==0)#") | formatNumber }}
-          {{ $qemu_total := len (.JSON.Array "data.#(type==\"qemu\")#|#(template==0)#") | formatNumber }}
-          {{ template "stat-value" (concat $qemu_running "/" $qemu_total) }}
-          {{ template "stat-label" "VM" }}
-        </div>
-        <div>
-          {{ $storage_available := len (.JSON.Array "data.#(type==\"storage\")#|#(status==\"available\")#") | formatNumber }}
-          {{ $storage_total := len (.JSON.Array "data.#(type==\"storage\")#") | formatNumber }}
-          {{ template "stat-value" (concat $storage_available "/" $storage_total) }}
-          {{ template "stat-label" "Storage" }}
-        </div>
+        {{ if eq .Response.StatusCode 200 }}
+          {{ $nodes_online := len (.JSON.Array "data.#(type==\"node\")#|#(status==\"online\")#") | formatNumber }}
+          {{ $nodes_total := len (.JSON.Array "data.#(type==\"node\")#") }}
+          <div>
+            {{ template "stat-value" (concat $nodes_online "/" ($nodes_total | formatNumber)) }}
+            {{ template "stat-label" "Node" }}
+          </div>
+          <div>
+            {{ $lxc_running := len (.JSON.Array "data.#(type==\"lxc\")#|#(status==\"running\")#|#(template==0)#") | formatNumber }}
+            {{ $lxc_total := len (.JSON.Array "data.#(type==\"lxc\")#|#(template==0)#") | formatNumber }}
+            {{ template "stat-value" (concat $lxc_running "/" $lxc_total) }}
+            {{ template "stat-label" "LXC" }}
+          </div>
+          <div>
+            {{ $qemu_running := len (.JSON.Array "data.#(type==\"qemu\")#|#(status==\"running\")#|#(template==0)#") | formatNumber }}
+            {{ $qemu_total := len (.JSON.Array "data.#(type==\"qemu\")#|#(template==0)#") | formatNumber }}
+            {{ template "stat-value" (concat $qemu_running "/" $qemu_total) }}
+            {{ template "stat-label" "VM" }}
+          </div>
+          <div>
+            {{ $storage_available := len (.JSON.Array "data.#(type==\"storage\")#|#(status==\"available\")#") | formatNumber }}
+            {{ $storage_total := len (.JSON.Array "data.#(type==\"storage\")#") | formatNumber }}
+            {{ template "stat-value" (concat $storage_available "/" $storage_total) }}
+            {{ template "stat-label" "Storage" }}
+          </div>
+        {{ else }}
+          {{ template "stat-fail" .Response.Status }}
+        {{ end }}
       </div>
     </div>

--- a/styles/stat-grid-style.css
+++ b/styles/stat-grid-style.css
@@ -11,6 +11,7 @@
     padding: 2px 4px;
     border-radius: var(--border-radius);
     font-size: 1rem;
-    flex: 1;
+    flex: 1 1 0;
     white-space: nowrap;
+    min-width: 0;
 }


### PR DESCRIPTION
Glance Native Error message looks off with this layout:

<img width="843" height="131" alt="image" src="https://github.com/user-attachments/assets/d8b3b80d-a7e1-4363-a61d-c2eb7b7b0c5c" />

---
Adding a custom handling would make things consistent layout-wise even with multiple endpoints:

<img width="850" height="128" alt="image" src="https://github.com/user-attachments/assets/e4dfdd3b-4030-45ed-b6d8-b029f355e34a" />
